### PR TITLE
Move i444 text replace before timecode generation.

### DIFF
--- a/global.bat
+++ b/global.bat
@@ -243,6 +243,7 @@ echo ----------------------
 echo  Generating timecodes
 echo ----------------------
 :: Timecodes ::
+".\programs\replacetext" "encode.avs" "i444 = false" "i444 = true"
 ".\programs\replacetext" "encode.avs" "pass = 0" "pass = 1"
 ".\programs\avs2pipemod" -benchmark encode.avs
 ".\programs\replacetext" "encode.avs" "pass = 1" "pass = 2"
@@ -252,7 +253,6 @@ echo  Encoding 10bit444 downloadable
 echo --------------------------------
 echo.
 :: Video ::
-".\programs\replacetext" "encode.avs" "i444 = false" "i444 = true"
 ".\programs\avs2pipemod" -y4mp encode.avs | ".\programs\x264_x64" --threads auto --sar "%VAR%" --crf 20 --keyint 600 --ref 16 --no-fast-pskip --bframes 16 --b-adapt 2 --direct auto --me tesa --merange 64 --subme 11 --trellis 2 --partitions all --no-dct-decimate --input-range pc --range pc --tcfile-in ".\temp\times.txt" -o ".\temp\video.mkv" --colormatrix smpte170m --output-csp i444 --profile high444 --output-depth 10 --demuxer y4m -
 :: Muxing ::
 ".\programs\mkvmerge" -o ".\output\encode.mkv" --timecodes -1:".\temp\times.txt" ".\temp\video.mkv" ".\temp\audio.opus"


### PR DESCRIPTION
Timecode generation for the 444 encode fails if the i444 flag is not set in encode.avs for pass 1. Subsequent encoding of the video does not succeed since timecodes are messed up and only a single frame is rendered.

I think this issue might be due to my environment somehow as this issue would stop encoders from getting the Modern HQ encode entirely if they are using the newest version of the repo. I am using Avisynth+ instead of plain Avisynth, so perhaps that is part of the issue?

Example:
```powershell
----------------------
 Generating timecodes
----------------------

avisynth_version 2.600 / AviSynth+ 3.4 (r2923, 3.4, i386)
script_name      encode.avs

v:width            160
v:height           144
v:image_type       framebased
v:field_order      not specified
v:pixel_type       YV12
v:bit_depth        8
v:number of planes 3
v:fps              60/1
v:frames           73800
v:duration[sec]    1230.000

avs2pipemod[info]: benchmarking 73800 frames video.
avs2pipemod[info]: [elapsed 0.001 sec] 0/73800 frames [  0%][0.000fps]avs2pipemod[error]:
--------------------------------
 Encoding 10bit444 downloadable
--------------------------------

avs2pipemod[info]: writing 1 frames of 60/1 fps, 160x144,
                   sar 0:0, YUV-444-planar-8bit progressive video.
y4m [info]: 160x144p 1:1 @ 60/1 fps (cfr)
timecode [info]: automatic timebase generation 1/60
x264 [info]: using SAR=1/1
x264 [info]: using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
x264 [info]: profile High 4:4:4 Predictive, level 1.2, 4:4:4 10-bit
avs2pipemod[info]: finished, wrote 1 frames [100%].
avs2pipemod[info]: total elapsed time is 0.062 sec.
x264 [info]: frame I:1     Avg QP:46.42  size:  4064
x264 [info]: mb I  I16..4:  7.8%  0.0% 92.2%
x264 [info]: coded y,u,v intra: 64.2% 8.9% 8.3%
x264 [info]: i16 v,h,dc,p: 14% 71%  0% 14%
x264 [info]: i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 17% 18% 16%  4%  3%  4%  7% 10% 21%
x264 [info]: kb/s:1950.72

encoded 1 frames, 0.10 fps, 2301.12 kb/s
```

Notice the `[error]` at the end of the timecodes generation section. After that, only a single frame is rendered. Also notice in the timecodes summary that the timecodes were generated for a YV12 video, as the `i444` flag is not set so the last command of `encode.avs` runs and converts the video to YV12.