### PR TITLE
Fix some subtitle placement issues due to timing.

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -31,6 +31,7 @@ subXoffs = 0		# subtitles horizontal offset (can be negative)
 subFont = "helv"	# see "fonts" folder for available types
 subFF2delay = 0		# extra delay in frames between subtitle entries 1 and 2
 subFF2delay2 = 0	# extra delay in frames between subtitle entries 2 and 3
+subFF2delay3 = 0	# extra delay in frames between subtitle entries 3 and 4
 bighaloCutoff = 384	# width and height above this will use bighalo instead of freesub
 
 #	Multisegment import (upscales hires segments straight to HD when needed)
@@ -262,6 +263,7 @@ subFontFile = "./fonts/" + subFontName + string(subSize) + ".bdf"
 subLength	= int(last.FrameRate * 5)
 subFF2		= SubFF  + subLength + 1 + subFF2delay
 subFF3		= SubFF2 + subLength + 1 + subFF2delay2
+subFF4		= SubFF3 + subLength + 1 + subFF2delay3
 subColor	= vb ? $009D9D9D : $00FFFFFF
 subRadius	= hd ? 0 : subHaloSize
 
@@ -308,7 +310,7 @@ subEntry == 3 || subEntry == 4 ? useBighalo ? vb ? 0 : ng_bighalo(subString2, \
 	text_color=subColor, halo_color=$00000000, lsp=2):0
 	
 subEntry == 3 ? useBighalo ? vb ? 0 : ng_bighalo(subString3 + "\n" + subString4,  \
-	x=subXpos, y=subYpos, align=subAlign, first_frame=subFF, \
+	x=subXpos, y=subYpos, align=subAlign, first_frame=subFF3, \
 	last_frame=subFF3+subLength, size=subSize, font_width=subWidth, \
 	text_color=subColor, halo_color=$00000000, lsp=2, halo_radius=subRadius) \
 : FreeSub(subString3 + "\n" + subString4,  \
@@ -329,13 +331,13 @@ subEntry == 4 ? useBighalo ? vb ? 0 : ng_bighalo(subString3,  \
 
 
 subEntry == 4 ? useBighalo ? vb ? 0 : ng_bighalo(subString4,  \
-	x=subXpos, y=subYpos, align=subAlign, first_frame=subff2 + subLength*2 + 1, \
-	last_frame=subff2+subLength*3, size=subSize, font_width=subWidth, \
+	x=subXpos, y=subYpos, align=subAlign, first_frame=subFF4, \
+	last_frame=subFF4+subLength, size=subSize, font_width=subWidth, \
 	text_color=subColor, halo_color=$00000000, lsp=2, halo_radius=subRadius) \
 : FreeSub(subString4,  \
 	x=subXpos, y=subYpos+subHaloSize, \
 	font=subFontFile, halo_width=subHaloSize, halo_height=subHaloSize, \
-	align=subAlign, first_frame=subff2 + subLength*2 + 1, last_frame=subff2+SubLength*3, \
+	align=subAlign, first_frame=subFF4, last_frame=subFF4+SubLength, \
 	text_color=subColor, halo_color=$00000000, lsp=2):0
 	
 #	Virtual Boy hacks


### PR DESCRIPTION
Subtitles for SD encodes have a slight timing issue between the third and fourth subtitles, for subtitles=4 mode.
![vCCWF5AFO0](https://user-images.githubusercontent.com/1929934/84464936-a8463a00-ac2a-11ea-96a8-6a733c736ec0.gif)
Notice in this GIF that the fourth subtitle is placed before the third subtitle clears. You can see it clear just after the fourth subtitle appears.

Subtitles for HD encodes have an issue where the third/fourth subtitle appear at the same time as the first subtitles:
![hd-subs-issue](https://user-images.githubusercontent.com/1929934/84465010-d7f54200-ac2a-11ea-9beb-e101d650b4bd.png)


For bighalo subtitles, there was a typo that caused timing of the third subtitle text to be placed immediately. There were some math issues that caused the 4th subtitle timing to be just a bit off, causing brief overlap.

Another user variable was added for a timing gap between 3rd and 4th subtitles for use with the 4 subtitles option.