### PR TITLE
Modify x264 settings for SD encodes for speed

### DIFF
--- a/global.bat
+++ b/global.bat
@@ -176,7 +176,7 @@ echo Encoding audio...
 
 :: Video ::
 echo Encoding video...
-".\programs\x264_x64" --threads auto --crf 20 --keyint 600 --ref 16 --no-fast-pskip --bframes 16 --b-adapt 2 --direct auto --me tesa --merange 64 --subme 11 --trellis 2 --partitions all --no-dct-decimate --range tv --input-range tv --colormatrix smpte170m -o ".\temp\video.h264" encode.avs
+".\programs\x264_x64" --threads auto --crf 20 --preset veryslow --keyint 600 --merange 64 --range tv --input-range tv --colormatrix smpte170m -o ".\temp\video.h264" encode.avs
 
 :: Muxing ::
 for /f "tokens=2 delims==" %%i in ('FINDSTR "r_frame_rate" "%~dp0temp\info.txt"') do (set fps=%%i)


### PR DESCRIPTION
Based on tests I've done, these settings should significantly speed up SD encodes compared to the current settings while keeping the size down and with a negligible perceptible difference in quality.

Might be related to this pull request, but I was debating on whether or not to remove the parameters `--range tv --input-range tv --colormatrix smpte170m` as x264 automatically pulls those settings from the source if they're not specified by the user and AVISynth can make those adjustments in the AVS script.