### PR TITLE
Max out YouTube 4K width at 3840 while maintaining aspect ratio

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -169,6 +169,15 @@ width	= (ARCorrection \
 		.ForceModulo(mod, true)
 hStretch= height / last.height
 
+# YouTube has a 4K width limit of 3840
+if (hd && (width > 3840)) {
+	width = 3840
+	height = (ARCorrection \
+		? width * hAspect / wAspect \
+		: width * last.height / last.width) \
+		.ForceModulo(mod, true)
+}
+
 #	Rescaling
 #	hd: resize to 4K, then just subsample with lanczos in the end
 #	handheld: do nothing


### PR DESCRIPTION
YouTube has a maximum width of 3840 for its 4K encodes. Any video wider than that will be resized down by YouTube for its 4K encodes so that the final width is 3840. This change will ensure that video the AVS script outputs will adhere to YouTube's 4K resolution limits: the width cannot be greater than 3840 and the height cannot be greater than 2160.