### PR TITLE
some systems need segments to be letterboxed to some overarching res

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -52,11 +52,13 @@ subSizepc = 5		# subtitles font size in percents of smaller video side
 #	requires normally importing a sample whose attributes it will use for all segments
 ms = false			# enable multisegment import
 msBase = "movie_"	# common string for all segment names
-msStart = 0		# number of the first segment
+msStart = 0			# number of the first segment
 msEnd = 15			# number of the last segment
 msFormat = "%1.0f"	# string format: http://avisynth.nl/index.php/Internal_functions#String
-msAudio = false	# use separate audio file for video
+msAudio = false		# use separate audio file for video
 msAudiotrack = "PSXjin.wav" # path to audio file
+msLetterbox = false	# import segments with letterboxing instead of resizing
+					# (initally imported clip is discarded)
 
 #	Aspect ratio correction
 wAspect = 4
@@ -108,6 +110,10 @@ audio = \
 ######################
 # AUTOMATED SETTINGS #
 ######################
+
+if (msLetterbox) {
+	AppendSegmentLetterbox(msBase, msStart, msEnd, msFormat, pixelType)
+}
 
 ConvertToRGB32()
 
@@ -187,7 +193,7 @@ resized = hd || ARCorrection \
 	: last
 
 #	If ms enabled, we use parameters of "resized" to apply to all segments
-if (ms) {
+if (ms && !msLetterbox) {
 	resized = resized \
 		.AppendSegment(msBase, msStart, msEnd, msFormat, resizer, hd, pixelType) \
 		.ConvertToRGB32()

--- a/encode.avs
+++ b/encode.avs
@@ -51,14 +51,13 @@ subSizepc = 5		# subtitles font size in percents of smaller video side
 #	Multisegment import (upscales hires segments straight to HD when needed)
 #	requires normally importing a sample whose attributes it will use for all segments
 ms = false			# enable multisegment import
+msLetterbox = false	# import segments with letterboxing instead of resizing
+					# (initally imported clip is discarded)
 msBase = "movie_"	# common string for all segment names
 msStart = 0			# number of the first segment
 msEnd = 15			# number of the last segment
 msFormat = "%1.0f"	# string format: http://avisynth.nl/index.php/Internal_functions#String
-msAudio = false		# use separate audio file for video
-msAudiotrack = "PSXjin.wav" # path to audio file
-msLetterbox = false	# import segments with letterboxing instead of resizing
-					# (initally imported clip is discarded)
+msAudioFile = ""	# path to external audio file. not used when empty
 
 #	Aspect ratio correction
 wAspect = 4
@@ -113,6 +112,10 @@ audio = \
 
 if (msLetterbox) {
 	AppendSegmentLetterbox(msBase, msStart, msEnd, msFormat, pixelType)
+	
+	if (msAudioFile != "") {
+		AudioDub(last, WavSource(msAudioFile))
+	}
 }
 
 ConvertToRGB32()
@@ -198,8 +201,8 @@ if (ms && !msLetterbox) {
 		.AppendSegment(msBase, msStart, msEnd, msFormat, resizer, hd, pixelType) \
 		.ConvertToRGB32()
 	
-	if (msAudio) {
-		resized = AudioDub(resized, WavSource(msAudiotrack))
+	if (msAudioFile != "") {
+		resized = AudioDub(resized, WavSource(msAudioFile))
 	}
 }
 

--- a/programs/functions.avsi
+++ b/programs/functions.avsi
@@ -34,7 +34,6 @@ function AppendSegment(
 
 # Multisegment AVI import via letterboxing
 function AppendSegmentLetterbox(
-\   clip sample,
 \ string base,
 \    int first_val,
 \    int last_val,

--- a/programs/functions.avsi
+++ b/programs/functions.avsi
@@ -1,4 +1,4 @@
-# Multisegment AVI import
+# Multisegment AVI import via resizing
 function AppendSegment(
 \   clip sample,
 \ string base,
@@ -21,6 +21,43 @@ function AppendSegment(
 			PointResize(int(temp_width), sample.height)
 			Lanczos4Resize(sample.width, sample.height)
 		}
+		
+		if (i == first_val) {
+			result = last
+		} else {
+			result = result + last
+		}
+	}
+	
+	return result
+}
+
+# Multisegment AVI import via letterboxing
+function AppendSegmentLetterbox(
+\   clip sample,
+\ string base,
+\    int first_val,
+\    int last_val,
+\ string format,
+\ string pix_type
+\){
+	biggest_width  = 0
+	biggest_height = 0
+	
+	for (i = first_val, last_val) {
+		filename = base + string(i, format) + ".avi"
+		AviSource(filename, pixel_type=pix_type)
+		biggest_width  = biggest_width  < last.width  ? last.width  : biggest_width
+		biggest_height = biggest_height < last.height ? last.height : biggest_height
+	}
+	
+	for (i = first_val, last_val) {
+		filename = base + string(i, format) + ".avi"
+		AviSource(filename, pixel_type=pix_type)
+		
+		xside = int(biggest_width  - last.width)  / 2
+		yside = int(biggest_height - last.height) / 2
+		AddBorders(xside, yside, xside, yside)
 		
 		if (i == first_val) {
 			result = last


### PR DESCRIPTION
- target resolution is deduced automatically by looking at all segments
- since we can letterbox at native res during initial import, resizing is not involved
- resize based MS import is incompatible with this setting

`msLetterbox` is the variable that enables this, has to be set in addition to `ms`.

fixed #18