### PR TITLE
Properly scale vertical encodes to 4K

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -164,8 +164,7 @@ width	= (ARCorrection \
 
 #	Actually go HD if we need
 if (hd) {
-	vertical        = ((width < height) && !ARCorrection) \
-		|| (ARCorrection && ((float(wAspect) / hAspect) < 1))
+	vertical        = width < height
 	
 	normalAspect	= ARCorrection ? float(wAspect) / hAspect \
 		: float(last.width) / last.height

--- a/encode.avs
+++ b/encode.avs
@@ -168,35 +168,33 @@ hARC	= height
 
 #	Actually go HD if we need
 if (hd) {
-	if (width >= height) {
-		height = 2160
-		width	= (ARCorrection \
-			? height * wAspect / hAspect \
-			: height * last.width / last.height) \
-			.ForceModulo(mod, true)
-		# YouTube has a 4K width limit of 3840 when width > height
-		if (width > 3840) {
-			width = 3840
-			height = (ARCorrection \
-				? width * hAspect / wAspect \
-				: width * last.height / last.width) \
-				.ForceModulo(mod, true)
-		}
-	} else {
-		width = 2160
-		height	= (ARCorrection \
-			? width * hAspect / wAspect \
-			: width * last.height / last.width) \
-			.ForceModulo(mod, true)
-		# YouTube has a 4K height limit of 3840 when height > width
-		if (height > 3840) {
-			height = 3840
-			width = (ARCorrection \
-				? height * wAspect / hAspect \
-				: height * last.width / last.height) \
-				.ForceModulo(mod, true)
-		}
+	vertical        = ((width < height) && !ARCorrection) \
+		|| (ARCorrection && ((float(wAspect) / hAspect) < 1))
+	
+	normalAspect	= ARCorrection ? float(wAspect) / hAspect \
+		: float(last.width) / last.height
+	reverseAspect	= ARCorrection ? float(hAspect) / wAspect \
+		: float(last.height) / last.width
+	
+	if (vertical) {
+		temp		= normalAspect
+		normalAspect	= reverseAspect
+		reverseAspect	= temp
 	}
+	
+	smallerSideCap  = 2160
+	biggerSideCap   = 3840
+	
+	smallerSideHD	= smallerSideCap
+	biggerSideHD	= int(smallerSideHD * normalAspect).ForceModulo(mod, true)
+	
+	if (biggerSideHD > biggerSideCap) {
+		biggerSideHD	= biggerSideCap
+		smallerSideHD	= int(biggerSideHD * reverseAspect).ForceModulo(mod, true)
+	}
+	
+	width	= vertical ? smallerSideHD : biggerSideHD
+	height	= vertical ? biggerSideHD  : smallerSideHD
 }
 
 #	Rescaling

--- a/encode.avs
+++ b/encode.avs
@@ -174,31 +174,29 @@ if (hd) {
 			? height * wAspect / hAspect \
 			: height * last.width / last.height) \
 			.ForceModulo(mod, true)
+		# YouTube has a 4K width limit of 3840 when width > height
+		if (width > 3840) {
+			width = 3840
+			height = (ARCorrection \
+				? width * hAspect / wAspect \
+				: width * last.height / last.width) \
+				.ForceModulo(mod, true)
+		}
 	} else {
 		width = 2160
 		height	= (ARCorrection \
 			? width * hAspect / wAspect \
 			: width * last.height / last.width) \
 			.ForceModulo(mod, true)
+		# YouTube has a 4K height limit of 3840 when height > width
+		if (height > 3840) {
+			height = 3840
+			width = (ARCorrection \
+				? height * wAspect / hAspect \
+				: height * last.width / last.height) \
+				.ForceModulo(mod, true)
+		}
 	}
-}
-
-#	YouTube has a 4K width limit of 3840 when width > height
-#	and a 4K height limit of 3840 when height > width
-if (hd) {}
-	if ((width >= height) && (width > 3840)) {
-		width = 3840
-		height = (ARCorrection \
-			? width * hAspect / wAspect \
-			: width * last.height / last.width) \
-			.ForceModulo(mod, true)
-	else if ((height > width) && (height > 3840)) {
-		height = 3840
-		width = (ARCorrection \
-			? height * wAspect / hAspect \
-			: height * last.width / last.height) \
-			.ForceModulo(mod, true)
-	 }
 }
 
 #	Rescaling

--- a/encode.avs
+++ b/encode.avs
@@ -156,7 +156,6 @@ if (prescaleFactor > 1 && !hd) {
 #	Aspect ratio correction for SD encodes
 #	if dimensions are not multiples of 4, codecs freak out, so we enforce mod 4
 mod		= 4
-hdHeight= 2160
 height	= last.height.ForceModulo(mod, true)
 width	= (ARCorrection \
 		? height * wAspect / hAspect \
@@ -169,22 +168,37 @@ hARC	= height
 
 #	Actually go HD if we need
 if (hd) {
-	height = hdHeight
+	if (width >= height) {
+		height = 2160
+		width	= (ARCorrection \
+			? height * wAspect / hAspect \
+			: height * last.width / last.height) \
+			.ForceModulo(mod, true)
+	} else {
+		width = 2160
+		height	= (ARCorrection \
+			? width * hAspect / wAspect \
+			: width * last.height / last.width) \
+			.ForceModulo(mod, true)
+	}
 }
 
-width	= (ARCorrection \
-		? height * wAspect / hAspect \
-		: height * last.width / last.height) \
-		.ForceModulo(mod, true)
-hStretch= height / last.height
-
-# YouTube has a 4K width limit of 3840
-if (hd && (width > 3840)) {
-	width = 3840
-	height = (ARCorrection \
-		? width * hAspect / wAspect \
-		: width * last.height / last.width) \
-		.ForceModulo(mod, true)
+#	YouTube has a 4K width limit of 3840 when width > height
+#	and a 4K height limit of 3840 when height > width
+if (hd) {}
+	if ((width >= height) && (width > 3840)) {
+		width = 3840
+		height = (ARCorrection \
+			? width * hAspect / wAspect \
+			: width * last.height / last.width) \
+			.ForceModulo(mod, true)
+	else if ((height > width) && (height > 3840)) {
+		height = 3840
+		width = (ARCorrection \
+			? height * wAspect / hAspect \
+			: height * last.width / last.height) \
+			.ForceModulo(mod, true)
+	 }
 }
 
 #	Rescaling

--- a/encode.avs
+++ b/encode.avs
@@ -162,10 +162,6 @@ width	= (ARCorrection \
 		: last.width) \
 		.ForceModulo(mod, true)
 
-#	Remember SD frame size for subYpos HD tweaks
-wARC	= width
-hARC	= height
-
 #	Actually go HD if we need
 if (hd) {
 	vertical        = ((width < height) && !ARCorrection) \


### PR DESCRIPTION
For vertical encodes, YouTube will not process them in 4K and instead in 1440p as the height is always fixed to 2160. This fixes it by setting the width to 2160 and scaling the height appropriately when the height is greater than the width. This change also takes into account the 3840 height limit for vertical encodes as it also applies there.