### PR TITLE
Fix multisegment SD resizing

### DIFF
--- a/programs/functions.avsi
+++ b/programs/functions.avsi
@@ -16,9 +16,9 @@ function AppendSegment(
 		if (hd) {
 			Eval(resizer + """Resize(sample.width, sample.height)""")
 		} else {
-			scaler = float(sample.height) / float(last.height)
-			temp_width = float(last.width) * scaler
-			PointResize(int(temp_width), sample.height)
+			scaler = int(float(sample.height) / float(last.height))
+			scaler = scaler < 1 ? 1 : scaler
+			PointResize(last.width * scaler, last.height * scaler)
 			Lanczos4Resize(sample.width, sample.height)
 		}
 		


### PR DESCRIPTION
The current code for SD multisegment resizing had PointResize() being used even if the current segment had dimensions that were less than 100% bigger (2x size). This led to sharp resizing artifacts that Lanczos4Rezize() should have covered up but didn't. This should fix it. Addresses issue #24 