### PR TITLE
Add an additional check for an uneven width.

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -120,9 +120,6 @@ if (msLetterbox) {
 
 ConvertToRGB32()
 
-#	Add 1 scanline if height is uneven (ntsc sms, pal c64)
-last.height % 2 > 0 ? StackVertical(last, Crop(0, Height-1, 0, 0)) : 0
-
 #	Make too dark scenes brighter
 # AutoLevels(filterRadius=1000, sceneChgThresh=200, gamma=1.1)
 
@@ -210,6 +207,10 @@ if (ms && !msLetterbox) {
 		resized = AudioDub(resized, WavSource(msAudioFile))
 	}
 }
+
+#	Pad out the width and/or height if they are still uneven
+resized.height % 2 > 0 ? StackVertical(resized, resized.Crop(0, resized.height-1, 0, 0)) : 0
+resized.width % 2 > 0 ? StackHorizontal(resized, resized.Crop(resized.width-1, 0, 0, 0)) : 0
 
 #	Logo
 logoVideo = ImageSource(file=file, start=0, end=int((resized.FrameRate * 2) - 1), fps=resized.FrameRate) \

--- a/encode.avs
+++ b/encode.avs
@@ -209,8 +209,12 @@ if (ms && !msLetterbox) {
 }
 
 #	Pad out the width and/or height if they are still uneven
-resized.height % 2 > 0 ? StackVertical(resized, resized.Crop(0, resized.height-1, 0, 0)) : 0
-resized.width % 2 > 0 ? StackHorizontal(resized, resized.Crop(resized.width-1, 0, 0, 0)) : 0
+if (resized.width % 2 > 0) {
+	resized = StackHorizontal(resized, resized.Crop(resized.width-1, 0, 0, 0))
+}	
+if (resized.height % 2 > 0) {
+	resized = StackVertical(resized, resized.Crop(0, resized.height-1, 0, 0))
+}
 
 #	Logo
 logoVideo = ImageSource(file=file, start=0, end=int((resized.FrameRate * 2) - 1), fps=resized.FrameRate) \


### PR DESCRIPTION
Certain parts of the script do not play well with uneven dimensions. There was a check for an uneven height, but not an uneven width. This fixes it.

Both checks are also moved to after the resizing functions as SD and HD resizing usually result in even dimensions. If neither happens or if uneven dimensions still remain, the checks will account for that.