### PR TITLE
Prevent encode from being turned into a YouTube short

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -183,6 +183,13 @@ if (hd) {
 	smallerSideHD	= smallerSideCap
 	biggerSideHD	= int(smallerSideHD * normalAspect).ForceModulo(mod, true)
 	
+	# Preliminary step to prevent encode from being turned into a YouTube short.
+	# Height will be set to 2160 and be the "bigger" side for vertical encodes.
+	if (vertical && last.FrameCount <= last.FrameRate * 58) {
+		biggerSideHD	= int(smallerSideHD * reverseAspect).ForceModulo(mod, true)
+		vertical = false
+	}
+	
 	if (biggerSideHD > biggerSideCap) {
 		biggerSideHD	= biggerSideCap
 		smallerSideHD	= int(biggerSideHD * reverseAspect).ForceModulo(mod, true)
@@ -204,6 +211,12 @@ if (ms && !msLetterbox) {
 	if (msAudioFile != "") {
 		resized = AudioDub(resized, WavSource(msAudioFile))
 	}
+}
+
+#	Apply borders if encode meets YouTube short qualifications.
+if (hd && width <= height && resized.FrameCount <= resized.FrameRate * 58) {
+	border = (height - width) / 2 + 8
+	resized = resized.AddBorders(border, 0, border, 0)
 }
 
 #	Logo

--- a/encode.avs
+++ b/encode.avs
@@ -185,7 +185,7 @@ if (hd) {
 	
 	# Preliminary step to prevent encode from being turned into a YouTube short.
 	# Height will be set to 2160 and be the "bigger" side for vertical encodes.
-	if (vertical && last.FrameCount <= last.FrameRate * 58) {
+	if (vertical && last.FrameCount <= last.FrameRate * 178) {
 		biggerSideHD	= int(smallerSideHD * reverseAspect).ForceModulo(mod, true)
 		vertical = false
 	}
@@ -214,7 +214,7 @@ if (ms && !msLetterbox) {
 }
 
 #	Apply borders if encode meets YouTube short qualifications.
-if (hd && width <= height && resized.FrameCount <= resized.FrameRate * 58) {
+if (hd && width <= height && resized.FrameCount <= resized.FrameRate * 178) {
 	border = (height - width) / 2 + 8
 	resized = resized.AddBorders(border, 0, border, 0)
 }


### PR DESCRIPTION
Recently, YouTube has been making AI edits to YouTube shorts possibly without the creator's permission. This, along with the YouTube Short format in general, is not acceptable for the type of content TASVideos wants to host. This part of the script will prevent the the video from being turned into a short.