### PR TITLE
Convert framerates for YouTube encodes when the FPS is between 30 and 41

### DIFF
--- a/encode.avs
+++ b/encode.avs
@@ -265,8 +265,9 @@ Trim(0, trimFrame)
 
 halfFPS ? SelectOdd : 0
 
-#	Youtube can't handle fps above 60
-hd && last.FrameRate > 60 ? ChangeFPS(60) : 0
+#	Youtube can't handle fps above 60 or between 30 and 41.
+hd && (last.FrameRate > 60 || (last.FrameRate > 30 && last.FrameRate < 41)) \
+	? ChangeFPS(60) : 0
 
 #	YV12 reduces chroma, so we use "lanczos" even for HD
 #	https://tasvideos.org/forum/viewtopic.php?t=19426


### PR DESCRIPTION
There are Flash games with framerates between 30 and 41. YouTube cannot handle those framerates and will convert down to 30 in those cases. This converts them up to 60 and retains the frames and motion of the original video.